### PR TITLE
fix can not compile to web

### DIFF
--- a/lib/field/math/bits.dart
+++ b/lib/field/math/bits.dart
@@ -20,7 +20,7 @@ class Bits {
     final BigInt w2 = t >> 32;
     w1 += x0 * y1;
     final BigInt high =
-        ((x1 * y1) & BigInt.from(0xFFFFFFFFFFFFFFFF)) + w2 + ((w1 >> 32));
+        ((x1 * y1) & BigInt.parse('FFFFFFFFFFFFFFFF', radix: 16)) + w2 + ((w1 >> 32));
     final BigInt low = (x * y) & _mask64;
     return (high, low);
   }

--- a/lib/field/math/bits.dart
+++ b/lib/field/math/bits.dart
@@ -20,7 +20,9 @@ class Bits {
     final BigInt w2 = t >> 32;
     w1 += x0 * y1;
     final BigInt high =
-        ((x1 * y1) & BigInt.parse('FFFFFFFFFFFFFFFF', radix: 16)) + w2 + ((w1 >> 32));
+        ((x1 * y1) & BigInt.parse('FFFFFFFFFFFFFFFF', radix: 16)) +
+            w2 +
+            ((w1 >> 32));
     final BigInt low = (x * y) & _mask64;
     return (high, low);
   }


### PR DESCRIPTION
fix error when build to web

```log
../../../.pub-cache/hosted/pub.dev/edwards25519-1.0.4/lib/field/math/bits.dart:23:34: Error: The integer literal 0xFFFFFFFFFFFFFFFF can't be represented exactly in JavaScript.
Try changing the literal to something that can be represented in JavaScript. In JavaScript 0x10000000000000000 is the nearest value that can be represented exactly.
        ((x1 * y1) & BigInt.from(0xFFFFFFFFFFFFFFFF)) + w2 + ((w1 >> 32));
                                 ^^^^^^^^^^^^^^^^^^
```

ref:

https://github.com/justkawal/edwards25519/blob/main/lib/field/math/bits.dart#L35